### PR TITLE
adding str to bytes conversion

### DIFF
--- a/starthinker/util/data/__init__.py
+++ b/starthinker/util/data/__init__.py
@@ -266,7 +266,18 @@ def put_rows(auth, destination, rows, variant=''):
     # put the file
     file_out = destination['storage']['bucket'] + ':' + destination['storage']['path'] + variant
     if project.verbose: print('SAVING', file_out)
-    object_put(auth, file_out, rows_to_csv(rows))
+
+    # @author hernanperalta
+    # fix type error when calling object_put
+    # the original line was:
+    # object_put(auth, file_out, rows_to_csv(rows))
+    # but this generates a type error, saying third param should be bytes, not str
+    # this might not be the best performing fix, but surely gets that csv in storage
+
+    import io
+    string_rows = rows_to_csv(rows)
+    byte_rows = io.BytesIO(string_rows.read().encode('utf8'))
+    object_put(auth, file_out, byte_rows)
 
   if 'sftp' in destination:
     try:


### PR DESCRIPTION
When running a task generated with the CLI using [dbm_to_storage.json](https://github.com/google/starthinker/blob/master/scripts/dbm_to_storage.json) as a template, in an environment with Python 3.7, it throws the next error:
```bash
>> python starthinker/task/dbm/run.py test_dbm_to_storage.json -u $STARTHINKER_USER -s $STARTHINKER_SERVICE -p $STARTHINKER_PROJECT

{'kind': 'doubleclickbidmanager#query', 'queryId': '699859424', 'metadata': {'title': 'starthinker-test', 'dataRange': 'LAST_7_DAYS', 'format': 'CSV', 'running': False, 'googleCloudStoragePathForLatestReport': 'https://storage.googleapis.com/dfa_-b8d7cf41be5eb53420e455d913fdfab19a164cc3/starthinker-test_20200528_174019_699859424_2921942814.csv?GoogleAccessId=573983893819-acfst5i6ba5a02rsdrjlpcfbq9k169sm@developer.gserviceaccount.com&Expires=1595947973&Signature=Axe3D7x7K3aYm7jha18WkuIv8DxctLwSff7sXBXhD5jR%2FqOsQczaAjU90kwRcVHNG7kodIkfEm3zc6rvtC3rJQWfne2rzZTT9eohLwOhtShRe%2FY7ZFKF9NYB5iu1X7EyNIjPTGnTDLfbC%2BxEDUTW1pFABo%2F7KihswsQ6Yazo0WM%3D', 'latestReportRunTimeMs': '1590687618379', 'sendNotification': False}, 'params': {'type': 'TYPE_GENERAL', 'groupBys': ['FILTER_ADVERTISER_NAME', 'FILTER_ADVERTISER', 'FILTER_ADVERTISER_CURRENCY', 'FILTER_INSERTION_ORDER_NAME', 'FILTER_INSERTION_ORDER', 'FILTER_LINE_ITEM_NAME', 'FILTER_LINE_ITEM', 'FILTER_PARTNER_CURRENCY'], 'metrics': ['METRIC_IMPRESSIONS', 'METRIC_BILLABLE_IMPRESSIONS', 'METRIC_CLICKS', 'METRIC_CTR', 'METRIC_TOTAL_CONVERSIONS', 'METRIC_LAST_CLICKS', 'METRIC_LAST_IMPRESSIONS', 'METRIC_REVENUE_ADVERTISER', 'METRIC_MEDIA_COST_ADVERTISER'], 'options': {'includeOnlyTargetedUserLists': False}}, 'schedule': {'frequency': 'DAILY', 'startTimeMs': '1590580800000', 'endTimeMs': '1590580800000', 'nextRunTimezoneCode': 'Pacific/Auckland'}}
Traceback (most recent call last):
  File "/home/herni/anaconda3/lib/python3.7/http/client.py", line 987, in send
    self.sock.sendall(data)
  File "/home/herni/anaconda3/lib/python3.7/ssl.py", line 1031, in sendall
    with memoryview(data) as view, view.cast("B") as byte_view:
TypeError: memoryview: a bytes-like object is required, not 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "starthinker/task/dbm/run.py", line 99, in <module>
    dbm()
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker/util/project/__init__.py", line 355, in from_parameters_wrapper
    func()
  File "starthinker/task/dbm/run.py", line 96, in dbm
    if rows: put_rows(project.task['auth'], project.task['out'], rows)
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker/util/data/__init__.py", line 269, in put_rows
    object_put(auth, file_out, rows_to_csv(rows))
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker/util/storage/__init__.py", line 161, in object_put
    status, response = request.next_chunk()
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker_virtualenv/lib/python3.7/site-packages/googleapiclient/_helpers.py", line 134, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker_virtualenv/lib/python3.7/site-packages/googleapiclient/http.py", line 1046, in next_chunk
    self.resumable_uri, method="PUT", body=data, headers=headers
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker_virtualenv/lib/python3.7/site-packages/google_auth_httplib2.py", line 198, in request
    uri, method, body=body, headers=request_headers, **kwargs)
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker_virtualenv/lib/python3.7/site-packages/httplib2/__init__.py", line 1994, in request
    cachekey,
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker_virtualenv/lib/python3.7/site-packages/httplib2/__init__.py", line 1651, in _request
    conn, request_uri, method, body, headers
  File "/home/herni/Desktop/starthinker-poc/starthinker/starthinker_virtualenv/lib/python3.7/site-packages/httplib2/__init__.py", line 1558, in _conn_request
    conn.request(method, request_uri, body, headers)
  File "/home/herni/anaconda3/lib/python3.7/http/client.py", line 1244, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/home/herni/anaconda3/lib/python3.7/http/client.py", line 1290, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/home/herni/anaconda3/lib/python3.7/http/client.py", line 1239, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/home/herni/anaconda3/lib/python3.7/http/client.py", line 1065, in _send_output
    self.send(chunk)
  File "/home/herni/anaconda3/lib/python3.7/http/client.py", line 991, in send
    self.sock.sendall(d)
  File "/home/herni/anaconda3/lib/python3.7/ssl.py", line 1031, in sendall
    with memoryview(data) as view, view.cast("B") as byte_view:
TypeError: memoryview: a bytes-like object is required, not 'str'
```

Referring to the next line:
https://github.com/google/starthinker/blob/818b036e80b5d1444ee71ae5aade7d10e868415d/starthinker/util/data/__init__.py#L269
Apparently this happens because `rows_to_csv()` returns a `StringIO`, and `object_put()` needs a `BytesIO`, at least for this specific use case. This is easily fixed by replacing that line with: 
```python
import io
string_rows = rows_to_csv(rows)
byte_rows = io.BytesIO(string_rows.read().encode('utf8'))
object_put(auth, file_out, byte_rows)
```